### PR TITLE
Fix exception on reload

### DIFF
--- a/forge/src/main/java/com/github/darkpred/morehitboxes/ForgeMoreHitboxesMod.java
+++ b/forge/src/main/java/com/github/darkpred/morehitboxes/ForgeMoreHitboxesMod.java
@@ -5,6 +5,7 @@ import com.github.darkpred.morehitboxes.internal.GeckoLibEvents;
 import com.github.darkpred.morehitboxes.internal.HitboxDataLoader;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.OnDatapackSyncEvent;
@@ -43,7 +44,11 @@ public class ForgeMoreHitboxesMod {
     }
 
     private void onDatapackSyncEvent(OnDatapackSyncEvent event) {
-        INSTANCE.send(PacketDistributor.PLAYER.with(event::getPlayer), new SyncHitboxDataMessage(HitboxDataLoader.HITBOX_DATA.getHitboxData()));
+        for(ServerPlayer p : event.getPlayers())
+        {
+            PacketDistributor.PacketTarget t = PacketDistributor.PLAYER.with(() -> p);
+            INSTANCE.send(t, new SyncHitboxDataMessage(HitboxDataLoader.HITBOX_DATA.getHitboxData()));
+        }
     }
 
     private static class SyncHitboxDataMessage {

--- a/forge/src/main/java/com/github/darkpred/morehitboxes/ForgeMoreHitboxesMod.java
+++ b/forge/src/main/java/com/github/darkpred/morehitboxes/ForgeMoreHitboxesMod.java
@@ -44,9 +44,18 @@ public class ForgeMoreHitboxesMod {
     }
 
     private void onDatapackSyncEvent(OnDatapackSyncEvent event) {
-        for(ServerPlayer p : event.getPlayers())
+        //On join
+        ServerPlayer p = event.getPlayer();
+        if(p != null)
         {
             PacketDistributor.PacketTarget t = PacketDistributor.PLAYER.with(() -> p);
+            INSTANCE.send(t, new SyncHitboxDataMessage(HitboxDataLoader.HITBOX_DATA.getHitboxData()));
+        }
+
+        //On reload
+        for(ServerPlayer sp : event.getPlayers())
+        {
+            PacketDistributor.PacketTarget t = PacketDistributor.PLAYER.with(() -> sp);
             INSTANCE.send(t, new SyncHitboxDataMessage(HitboxDataLoader.HITBOX_DATA.getHitboxData()));
         }
     }


### PR DESCRIPTION
Related to issue #5 
When reloading, the mod tried to send a packet to the player of the onDatapackSyncEvent. This player is null when reloading, causing it to fail.
I debated whether to just add a check if the specified player is not null, but I believe the event should be used for syncing the hitbox data with all players on a server.
I'm not entirely sure if the fix implemented carries the same functionality as intended, but I believe this is the optimal solution.
Please correct me if I'm wrong.